### PR TITLE
Fix: database password must not include an @ character

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   terraform:
     name: 'Terraform'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:

--- a/main.tf
+++ b/main.tf
@@ -156,7 +156,9 @@ module "ecs-service-cloudwatch-dashboard" {
  * Create RDS root password
  */
 resource "random_password" "db_root" {
-  length           = 16
+  length = 16
+
+  # this list is the same as the default list with only '@' removed
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -156,7 +156,8 @@ module "ecs-service-cloudwatch-dashboard" {
  * Create RDS root password
  */
 resource "random_password" "db_root" {
-  length = 16
+  length           = 16
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
 /*
@@ -169,7 +170,7 @@ module "rds" {
   app_env           = local.app_env
   db_name           = var.database_name
   db_root_user      = var.database_user
-  db_root_pass      = random_password.db_root.result
+  db_root_pass      = local.db_password
   subnet_group_name = module.vpc.db_subnet_group_name
   security_groups   = [module.vpc.vpc_default_sg_id]
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,7 +12,7 @@ output "database_host" {
 }
 
 output "database_password" {
-  value     = random_password.db_root.result
+  value     = local.db_password
   sensitive = true
 }
 

--- a/vpc.tf
+++ b/vpc.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_log_group" "vpc_flow_log" {
 }
 
 resource "aws_iam_role" "vpc_flow_log" {
-  name = "VPCFlowLog-${local.app_name_and_env}"
+  name = "VPCFlowLog-${local.app_name_and_env}-${local.region}"
 
   assume_role_policy = <<EOF
 {


### PR DESCRIPTION
### Fixed
- Restrict the allowed characters in the database password creation to comply with RDS requirements.
- Use the local identifier that was already created to reference the database password.
- Specify the OS version for the test runner.