### PR TITLE
Release 0.3.0 - add dns_allow_overwrite

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -224,19 +224,15 @@ module "ecs" {
 resource "cloudflare_record" "dns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id = data.cloudflare_zones.domain.zones[0].id
+  zone_id = data.cloudflare_zone.this.id
   name    = var.subdomain
   value   = module.alb.dns_name
   type    = "CNAME"
   proxied = true
 }
 
-data "cloudflare_zones" "domain" {
-  filter {
-    name        = var.domain_name
-    lookup_type = "exact"
-    status      = "active"
-  }
+data "cloudflare_zone" "this" {
+  name = var.domain_name
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -224,11 +224,12 @@ module "ecs" {
 resource "cloudflare_record" "dns" {
   count = var.create_dns_record ? 1 : 0
 
-  zone_id = data.cloudflare_zone.this.id
-  name    = var.subdomain
-  value   = module.alb.dns_name
-  type    = "CNAME"
-  proxied = true
+  zone_id         = data.cloudflare_zone.this.id
+  name            = var.subdomain
+  value           = module.alb.dns_name
+  type            = "CNAME"
+  proxied         = true
+  allow_overwrite = var.dns_allow_overwrite
 }
 
 data "cloudflare_zone" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,12 @@ variable "create_dns_record" {
   type        = bool
 }
 
+variable "dns_allow_overwrite" {
+  description = "Controls whether this module can overwrite an existing DNS record with the same name. Can be used in a multiregion DNS-based failover configuration."
+  type        = bool
+  default     = false
+}
+
 variable "domain_name" {
   description = "The domain name on which to host the app. Combined with \"subdomain\" to create an ALB listener rule. Also used for the optional DNS record."
   type        = string


### PR DESCRIPTION
### Added
- New variable `dns_allow_overwrite` to provide a DNS failover option that does not require manually removing the failing region's CNAME.