### PR TITLE
update module dependencies; add optional `rds_ca_cert_identifier` input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -166,15 +166,16 @@ resource "random_password" "db_root" {
  * Create an RDS database
  */
 module "rds" {
-  source = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=8.2.1"
+  source = "github.com/silinternational/terraform-modules//aws/rds/mariadb?ref=8.8.0"
 
-  app_name          = var.app_name
-  app_env           = local.app_env
-  db_name           = var.database_name
-  db_root_user      = var.database_user
-  db_root_pass      = local.db_password
-  subnet_group_name = module.vpc.db_subnet_group_name
-  security_groups   = [module.vpc.vpc_default_sg_id]
+  app_name           = var.app_name
+  app_env            = local.app_env
+  ca_cert_identifier = var.rds_ca_cert_identifier
+  db_name            = var.database_name
+  db_root_user       = var.database_user
+  db_root_pass       = local.db_password
+  subnet_group_name  = module.vpc.db_subnet_group_name
+  security_groups    = [module.vpc.vpc_default_sg_id]
 
   allocated_storage = 20 // 20 gibibyte
   instance_class    = "db.t3.micro"
@@ -206,7 +207,7 @@ module "adminer" {
  * Create new ecs service
  */
 module "ecs" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.2.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.8.0"
   cluster_id         = module.ecsasg.ecs_cluster_id
   service_name       = var.app_name
   service_env        = local.app_env

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,12 @@ variable "default_cert_domain_name" {
  * Database configuration
  */
 
+variable "rds_ca_cert_identifier" {
+  description = "The identifier of the CA certificate for the DB instance."
+  default     = null
+  type        = string
+}
+
 variable "database_name" {
   description = "The name assigned to the created database"
   default     = "db"

--- a/vpc.tf
+++ b/vpc.tf
@@ -3,17 +3,18 @@
  * Create VPC
  */
 module "vpc" {
-  source    = "github.com/silinternational/terraform-modules//aws/vpc?ref=8.2.1"
+  source    = "github.com/silinternational/terraform-modules//aws/vpc?ref=8.8.0"
   app_name  = var.app_name
   app_env   = var.app_env
   aws_zones = var.aws_zones
+
 }
 
 /*
  * Security group to limit traffic to Cloudflare IPs
  */
 module "cloudflare-sg" {
-  source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=8.2.1"
+  source = "github.com/silinternational/terraform-modules//aws/cloudflare-sg?ref=8.8.0"
   vpc_id = module.vpc.id
 }
 
@@ -89,7 +90,7 @@ data "aws_acm_certificate" "default" {
  * Create application load balancer for public access
  */
 module "alb" {
-  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=8.2.1"
+  source          = "github.com/silinternational/terraform-modules//aws/alb?ref=8.8.0"
   app_name        = var.app_name
   app_env         = var.app_env
   internal        = "false"
@@ -106,7 +107,7 @@ module "alb" {
  */
 module "ecsasg" {
   source                = "silinternational/ecs-asg/aws"
-  version               = "3.0.1"
+  version               = "3.1.0"
   cluster_name          = local.app_name_and_env
   subnet_ids            = module.vpc.private_subnet_ids
   security_group_ids    = [module.vpc.vpc_default_sg_id]


### PR DESCRIPTION
### Added
- Added an optional variable `rds_ca_cert_identifier` input.

### Changed
- Updated `silinternational/terraform-modules` to 8.8.0 ([Release notes](https://github.com/silinternational/terraform-modules/releases))
- Updated `silinternational/ecs-asg/aws` to 3.1.0 ([Release notes](https://github.com/silinternational/terraform-aws-ecs-asg/releases/tag/3.1.0))
  - This update adds a `Name` tag to the asg resource, which shows on the "Name" column of the instance table.