### PR TITLE
Release 0.7.0 -- add a new variable to assign tags to the ASG

### DIFF
--- a/test/test.tf
+++ b/test/test.tf
@@ -43,6 +43,9 @@ module "full" {
     timeout             = 10
     unhealthy_threshold = 3
   }
+  asg_tags = {
+    foo = "bar",
+  }
 }
 
 provider "aws" {

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,12 @@ variable "asg_max_size" {
   type        = number
 }
 
+variable "asg_tags" {
+  description = "Tags to assign to the Autoscaling Group and EC2 instances"
+  default     = {}
+  type        = map(string)
+}
+
 variable "instance_type" {
   description = "See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes"
   default     = "t2.micro"

--- a/vpc.tf
+++ b/vpc.tf
@@ -118,4 +118,5 @@ module "ecsasg" {
   ssh_key_name          = var.ssh_key_name
   use_amazon_linux2     = true
   instance_type         = var.instance_type
+  tags                  = var.asg_tags
 }


### PR DESCRIPTION
[ITSE-733](https://itse.youtrack.cloud/issue/ITSE-733) Add missing tags to AWS objects

---

### Added
- Added a new variable, `asg_tags`, to assign tags to the autoscaling group and EC2 instances.