### PR TITLE
Release v0.10.5 - Add `asg_additional_user_data` variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,12 @@ variable "alarm_actions_enabled" {
   type        = bool
 }
 
+variable "asg_additional_user_data" {
+  description = "Bash code to append to the default EC2 user_data."
+  type        = string
+  default     = ""
+}
+
 variable "asg_min_size" {
   description = "The minimum size of the Autoscaling Group"
   default     = 1

--- a/vpc.tf
+++ b/vpc.tf
@@ -113,7 +113,7 @@ module "alb" {
  */
 module "ecsasg" {
   source  = "silinternational/ecs-asg/aws"
-  version = "~> 4.0"
+  version = "~> 4.1"
 
   cluster_name                   = local.app_name_and_env
   subnet_ids                     = module.vpc.private_subnet_ids
@@ -128,4 +128,5 @@ module "ecsasg" {
   tags                           = var.asg_tags
   enable_ipv6                    = var.enable_ipv6
   enable_ec2_detailed_monitoring = var.enable_ec2_detailed_monitoring
+  additional_user_data           = var.asg_additional_user_data
 }


### PR DESCRIPTION
[IDP-1631](https://support.gtis.sil.org/issue/IDP-1631)

---

### WAITING FOR
- #22 

---

### Added
- Add a way to provide additional content for the EC2 user data script (in the Launch Template), used by the Auto-Scaling Group for this app's ECS Cluster